### PR TITLE
add typings for typescript support

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,49 @@
+import * as React from 'react';
+
+export type Position = 'top' | 'bottom' | 'left' | 'right';
+export type Trigger = 'mouseenter' | 'focus click' | 'manual';
+export type Animation = 'shift' | 'perspective' | 'fade scale' | 'none';
+export type Size = 'small' | 'regular' | 'big';
+export type Theme = 'dark' | 'light' | 'transparent';
+
+export interface TooltipProps {
+    disabled?: boolean;
+    open?: boolean;
+    useContext?: boolean;
+    onRequestClose?: () => void;
+    position?: Position;
+    trigger?: Trigger;
+    tabIndex?: number;
+    interactive?: boolean;
+    interactiveBorder?: number;
+    delay?: number;
+    hideDelay?: number;
+    animation?: Animation;
+    arrow?: boolean;
+    arrowSize?: Size;
+    animateFill?: boolean;
+    duration?: number;
+    hideDuration?: number;
+    distance?: number;
+    offset?: number;
+    hideOnClick?: boolean | 'persistent';
+    multiple?: boolean;
+    followCursor?: boolean;
+    inertia?: boolean;
+    transitionFlip?: boolean;
+    popperOptions?: any;
+    html?: React.ReactElement<any>;
+    unmountHTMLWhenHide?: boolean;
+    size?: Size;
+    sticky?: boolean;
+    stickyDuration?: boolean;
+    beforeShown?: () => void;
+    shown?: () => void;
+    beforeHidden?: () => void;
+    hidden?: () => void;
+    theme?: Theme;
+    className?: string;
+    style?: React.CSSProperties;
+}
+
+export class Tooltip extends React.Component<TooltipProps> { }

--- a/index.d.ts
+++ b/index.d.ts
@@ -7,6 +7,7 @@ export type Size = 'small' | 'regular' | 'big';
 export type Theme = 'dark' | 'light' | 'transparent';
 
 export interface TooltipProps {
+    title?: string;
     disabled?: boolean;
     open?: boolean;
     useContext?: boolean;
@@ -47,3 +48,5 @@ export interface TooltipProps {
 }
 
 export class Tooltip extends React.Component<TooltipProps> { }
+
+export declare function withTooltip<P>(component: React.ComponentType<P>, options: TooltipProps);

--- a/package.json
+++ b/package.json
@@ -46,7 +46,10 @@
     "build": "webpack --config webpacklib.config.js --env build",
     "start": "react-scripts start"
   },
-  "dependencies": {
-    "popper.js": "^1.11.1"
-  }
+},
+"dependencies": {
+"popper.js": "^1.11.1",
+"@types/react": "*"
+},
+"typings": "./index.d.ts"
 }


### PR DESCRIPTION
Typescript is getting more and more popular, even in the React community, and for a reason. Strong typing avoids typos and catches errors at compile time that otherwise would be thrown during runtime.

This PR adds typescript support to tippy.