### PR TITLE
check browser support and don't initialize tippy if not supported

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,7 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+
+# IDEA/Webstorm project files
+.idea
+*.iml

--- a/src/Tooltip/component.js
+++ b/src/Tooltip/component.js
@@ -1,5 +1,6 @@
 import React, { Component } from 'react';
 import tippy from './js/tippy';
+import {Browser} from './js/core/globals';
 
 const defaultProps = {
   html: null,
@@ -176,7 +177,7 @@ class Tooltip extends Component {
   }
 
   _initTippy() {
-    if (typeof window === 'undefined' || typeof document === 'undefined' ) {
+      if (typeof window === 'undefined' || typeof document === 'undefined' || !Browser.SUPPORTED) {
       return;
     }
     if (!this.props.disabled) {


### PR DESCRIPTION
If running in an environment where the Browser has insufficient support, the component is still initialized but has no store. Consequently, all further operations throw exceptions.

This is very common when used in automatic tests, e.g. using jest/enzyme or a similar test tool will generate components that are not running in a browser environment. Thus, tippy currently breaks all automatic tests.

This PR adds an additional check so it isn't even initialized and doesn't throw exceptions during testing.