### PR TITLE
Don't restore HTML title popover after destroying tip

### DIFF
--- a/src/Tooltip/js/tippy.js
+++ b/src/Tooltip/js/tippy.js
@@ -387,9 +387,6 @@ class Tippy {
     // Remove Tippy-only event listeners from tooltipped element
     listeners.forEach(listener => el.removeEventListener(listener.event, listener.handler))
 
-    // Restore original title
-    el.setAttribute('title', el.getAttribute('data-original-title'))
-
     el.removeAttribute('data-original-title')
     el.removeAttribute('data-tooltipped')
     el.removeAttribute('aria-describedby')


### PR DESCRIPTION
Fixes #47