### PR TITLE
Add support to zIndex prop

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@ const HeaderWithTootip = withTooltip(Header, {
 |theme|`dark`|`dark` `light` `transparent`|The CSS styling theme.|
 |className|''|string|className of container|
 |style|{}|React inline style (object)|style of container|
+|zIndex|9999|number|Specifies the z-index of the tooltip popper|
 
 
 ## Custom tooltip content

--- a/src/App.js
+++ b/src/App.js
@@ -180,10 +180,24 @@ class App extends Component {
             Sticky
           </p>
         </Tooltip>
+        
+        <hr />
+        
+        <Tooltip
+          // options
+          title="z-index set to 2"
+          trigger="mouseenter"
+          zIndex={2}
+        >
+          Custom z-index
+        </Tooltip>
+        
+        <hr />
+        
         <button onClick={() => { console.log('call open'); setIsOpen(true) }}>
           Do something
         </button>
-        <hr />
+        
         <Tooltip
           disabled={disabled}
           title={tooltipContent}

--- a/src/Tooltip/component.js
+++ b/src/Tooltip/component.js
@@ -36,6 +36,7 @@ const defaultProps = {
   stickyDuration: 200,
   touchHold: false,
   unmountHTMLWhenHide: false,
+  zIndex: 9999
 };
 
 const propKeys = Object.keys(defaultProps)
@@ -220,6 +221,7 @@ class Tooltip extends Component {
         reactInstance: this.props.useContext ? this : undefined,
         performance: true,
         html: this.props.rawTemplate ? this.props.rawTemplate : undefined,
+        zIndex: this.props.zIndex
       });
       if (this.props.open) {
         this.showTooltip();


### PR DESCRIPTION
Add `zIndex` prop support to react-tippy.

It basically passes the provided zIndex prop down to popper.

It fixes issue #31 