### PR TITLE
Fix settings of undefined

### DIFF
--- a/src/Tooltip/js/core/bindEventListeners.js
+++ b/src/Tooltip/js/core/bindEventListeners.js
@@ -52,12 +52,16 @@ export default function bindEventListeners() {
 
     if (popper) {
       const ref = find(Store, ref => ref.popper === popper)
+      if (!ref) return;
+
       const { settings: { interactive } } = ref
       if (interactive) return
     }
 
     if (el) {
       const ref = find(Store, ref => ref.el === el)
+      if (!ref) return;
+
       const {
         settings: {
           hideOnClick,

--- a/src/Tooltip/js/core/followCursorHandler.js
+++ b/src/Tooltip/js/core/followCursorHandler.js
@@ -11,6 +11,7 @@ import closest          from '../utils/closest'
 */
 export default function followCursorHandler(e) {
   const refData = find(Store, refData => refData.el === this)
+  if (!refData) return;
 
   const {
     popper,

--- a/src/Tooltip/js/tippy.js
+++ b/src/Tooltip/js/tippy.js
@@ -112,6 +112,8 @@ class Tippy {
 
   updateSettings(popper, name, value) {
     const data = find(this.store, data => data.popper === popper)
+    if (!data) return;
+
     const newSettings = {
       ...data.settings,
       [name]: value,
@@ -127,6 +129,7 @@ class Tippy {
   updateForReact(popper, updatedContent) {
     const tooltipContent = popper.querySelector(Selectors.CONTENT)
     const data = find(this.store, data => data.popper === popper)
+    if (!data) return;
 
     const {
       useContext,
@@ -155,6 +158,8 @@ class Tippy {
     if (this.state.destroyed) return
 
     const data = find(this.store, data => data.popper === popper)
+    if (!data) return;
+
     const { tooltip, circle, content } = getInnerElements(popper)
 
     if (!document.body.contains(data.el)) {
@@ -165,7 +170,7 @@ class Tippy {
     this.callbacks.show.call(popper)
 
     // Custom react
-    if (data && data.settings && data.settings.open === false) {
+    if (data.settings && data.settings.open === false) {
       return;
     }
 
@@ -263,6 +268,8 @@ class Tippy {
     this.callbacks.hide.call(popper)
 
     const data = find(this.store, data => data.popper === popper)
+    if (!data) return;
+
     const { tooltip, circle, content } = getInnerElements(popper)
 
     // custom react
@@ -347,6 +354,8 @@ class Tippy {
     if (this.state.destroyed) return
 
     const data = find(this.store, data => data.popper === popper)
+    if (!data) return;
+
     const { content } = getInnerElements(popper)
     const { el, settings: { html } } = data
 
@@ -371,6 +380,7 @@ class Tippy {
     if (this.state.destroyed) return
 
     const data = find(this.store, data => data.popper === popper)
+    if (!data) return;
 
     const {
       el,


### PR DESCRIPTION
Add safeguard for each `find` within code base

# ROOT CAUSE
We are using globals variables within `globals.js`,

```js
src/Tooltip/js/core/globals.js

/**
* The global storage array which holds all data reference objects
* from every instance
* This allows us to hide tooltips from all instances, finding the ref when
* clicking on the body, and for followCursor
*/
export const Store = []
```

but they're not actually ***global***, thus making the duplication for react-tippy could be import multiple time through multiple ways.

eg:

```js
import { Tooltip } from 'react-tippy'; <- 1st time
import { AComponentWhichUseReactTippyInternally } from 'another-lib'; <- 2nd time

const MyComponent = props => (
  <div>
    <AComponentWhichUseReactTippyInternally />
    <Tooltip title="a pure tooltip">
      <span>pure tooltip</span>
    </Tooltip>
  </div>
);
```

and that's how the issue happened as multiple `Store`s from `globals.js` would be created and used when they are imported. And every click on a tooltip component will trigger the event listener and that search for both `Store`s and as just one is matched, others would return undefined and without the safeguard they would keep digging for settings and thus raise the error.