### PR TITLE
added a more robust (but succinct) e.g. of showing/hiding tooltip in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,14 +171,26 @@ You can use `interactive` prop and `html` for your interactive tooltip
 ## Show/hide your tooltip manually
 
 ```javascript
+
+state = {
+  open: false,
+}
+
+// ...
+
 <Tooltip
-  title={tooltipContent}
-  open={open}
-  onRequestClose={() => {console.log('call'); setIsOpen(false)}}
+  open={this.state.open}
 >
-  <span className="App-intro" onClick={() => { setIsOpen(true) }}>
-    This will show {tooltipContent}
-  </span>
+  <p
+    onClick={() => {
+      this.setState(state => ({
+        open: !state.open,
+      }));
+      setTimeout(() => alert('can do things after delay'), 2000);
+    }}
+  >
+  Clicking me will initiate manual open/close tooltip logic
+  </p>
 </Tooltip>
 ```
 


### PR DESCRIPTION
The previous e.g. for showing/hiding tooltip manually was good, but I thought could be improved, as for e.g. I was not sure what `{open}` was in `open={open}`

Also, I only realized `setIsOpen()` in previous e.g. worked because we were assuming a controlled component.

So my pr does the following:
1)  explicitly show that when using the prop `open`, we probably need a controlled component with 
```
state = {
  open: false,
}
```
2) demonstrate the ability to have a tooltip with a click trigger, which can then linger for a set amount of time (making this e.g. more practical and robust)
`setTimeout(() => alert('can do things after delay'), 2000);`
