### PR TITLE
prevent hiding all tooltips when the clicked element was unmounted

### DIFF
--- a/src/Tooltip/js/core/bindEventListeners.js
+++ b/src/Tooltip/js/core/bindEventListeners.js
@@ -46,6 +46,11 @@ export default function bindEventListeners() {
     if (!(event.target instanceof Element)) {
       return hideAllPoppers()
     }
+    
+    // Ignore clicks on elements unmounted from the DOM
+    if (!document.body.contains(event.target)) {
+      return;
+    }
 
     const el = closest(event.target, Selectors.TOOLTIPPED_EL)
     const popper = closest(event.target, Selectors.POPPER)


### PR DESCRIPTION
**The problem**:
* a user clicks on an element inside the tooltip
* the element is removed from the DOM (by updating innerHTML or unmounting it)
* `clickHandler` can't find closest popper and calls `hideAllPoppers()`, hiding the tooltip

**The solution**: if the click target is not connected to `document.body` then ignore the click event.

I don't think this is an intended feature, and if so then it should be configurable.