### PR TITLE
Fix issues related to title and html props

### DIFF
--- a/src/Tooltip/component.js
+++ b/src/Tooltip/component.js
@@ -181,7 +181,9 @@ class Tooltip extends Component {
       return;
     }
     if (!this.props.disabled) {
-      this.tooltipDOM.setAttribute('title', this.props.title);
+      if (this.props.title) {
+        this.tooltipDOM.setAttribute('title', this.props.title);
+      }
       this.tippy = tippy(this.tooltipDOM, {
         disabled: this.props.disabled,
         position: this.props.position,

--- a/src/Tooltip/js/core/createTooltips.js
+++ b/src/Tooltip/js/core/createTooltips.js
@@ -25,10 +25,10 @@ export default function createTooltips(els) {
         : getIndividualSettings(el, this.settings)
     )
 
-    const { html, trigger, touchHold } = settings
+    const { reactDOM, trigger, touchHold } = settings
 
     const title = el.getAttribute('title')
-    if (!title && !html) return a
+    if (!title && !reactDOM) return a
 
     el.setAttribute('data-tooltipped', '')
     el.setAttribute('aria-describedby', `tippy-tooltip-${id}`)


### PR DESCRIPTION
### Description

I noticed that `react-tippy` wasn't working on IE11. I was getting this error message:

```
[getPopperElement]: Element passed as the argument does not exist in the instance
```

Digging in, I discovered that [this line](https://github.com/tvkhoa/react-tippy/blob/master/src/Tooltip/component.js#L184) seemed partly responsible: if the `title` prop is `null`, IE 11 sets the attribute to `""` whereas all other browsers actually set the attribute to `"null"`. In `createTooltips`, [this predicate](https://github.com/tvkhoa/react-tippy/blob/master/src/Tooltip/js/core/createTooltips.js#L31) looks for a truthy `title` attribute or `html` setting. The predicate is essentially skipped for all browsers aside from IE 11 (unless `""` was explicitly passed in as the `title`) since `"null"` is not falsy. 

The other problem with [this predicate](https://github.com/tvkhoa/react-tippy/blob/master/src/Tooltip/js/core/createTooltips.js#L31) is that it is checking the `html` setting which does not seem to be the intent, since the `html` prop is stored as the `reactDOM` setting on [this line](https://github.com/tvkhoa/react-tippy/blob/master/src/Tooltip/component.js#L212). Also, the `html` setting was introduced in [this changeset line](https://github.com/tvkhoa/react-tippy/commit/3b16f0a6ad6f778d6f4799582761146ecb160c30#diff-b058448fbaeb8bf279e1f8a075949e6dR222) which does not touch the predicate in `createTooltips`.

These changes fix the IE 11 issue for me; they also do not affect the behavior in other browsers and the test app works.

