### PR TITLE
Feat: Allow popper to receive zIndex from user settings

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-tippy",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "description": "React tippy",
   "main": "dist/react-tippy.js",
   "files": [

--- a/src/Tooltip/component.js
+++ b/src/Tooltip/component.js
@@ -37,9 +37,10 @@ const defaultProps = {
   stickyDuration: 200,
   touchHold: false,
   unmountHTMLWhenHide: false,
+  zIndex: 9999
 };
 
-const propKeys = Object.keys(defaultProps)
+const propKeys = Object.keys(defaultProps);
 
 const detectPropsChanged = (props, prevProps) => {
   const result = [];
@@ -221,6 +222,7 @@ class Tooltip extends Component {
         reactInstance: this.props.useContext ? this : undefined,
         performance: true,
         html: this.props.rawTemplate ? this.props.rawTemplate : undefined,
+        zIndex: this.props.zIndex
       });
       if (this.props.open) {
         this.showTooltip();


### PR DESCRIPTION
By default, react-tippy set tippy-popper's z-index to 9999, this change will allow user to pass their own value. 
Example:
```js
<Tooltip
  useContext
  position="bottom-end"
  trigger="manual"
  theme="dark-info"
  html={<NotificationList closeActivityFeed={closeActivityFeed} />}
  interactive
  arrow
  arrowSize="big"
  distance={15}
  offset={30}
  open={tooltipOpenState}
  onRequestClose={closeActivityFeed}
  zIndex={10000}
>
  <div style={styles.tooltipTrigger} onClick={openActivityFeed}>
    <Icon name="ui-1_bell-53" style={styles.bellIcon} />
    {counter > 0 && (
      <Badge type="danger" text={counter} style={styles.countBadge} />
    )}
  </div>
</Tooltip>
```