### PR TITLE
corrected type for `stickyDuration`

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -49,7 +49,7 @@ export interface TooltipProps {
   unmountHTMLWhenHide?: boolean;
   size?: Size;
   sticky?: boolean;
-  stickyDuration?: boolean;
+  stickyDuration?: number;
   beforeShown?: () => void;
   shown?: () => void;
   beforeHidden?: () => void;


### PR DESCRIPTION
It should actually be number. :)