### PR TITLE
Fix type for delay prop

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -29,7 +29,7 @@ export interface TooltipProps {
   tabIndex?: number;
   interactive?: boolean;
   interactiveBorder?: number;
-  delay?: number;
+  delay?: number | [number, number];
   hideDelay?: number;
   animation?: Animation;
   arrow?: boolean;


### PR DESCRIPTION
Should be number | [number, number] according to
https://github.com/tvkhoa/react-tippy/issues/52