### PR TITLE
Add zIndex prop to type definition

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -57,6 +57,7 @@ export interface TooltipProps {
   theme?: Theme;
   className?: string;
   style?: React.CSSProperties;
+  zIndex?: number;
 }
 
 export class Tooltip extends React.Component<TooltipProps> {}


### PR DESCRIPTION
`zIndex` prop was introduced in [this PR](https://github.com/tvkhoa/react-tippy/pull/129) but it was not included in the type definitions.