### PR TITLE
Check if data-original-title exists before assign it to the title attribute

### DIFF
--- a/src/Tooltip/js/tippy.js
+++ b/src/Tooltip/js/tippy.js
@@ -402,7 +402,8 @@ class Tippy {
     listeners.forEach(listener => el.removeEventListener(listener.event, listener.handler))
 
     // Restore original title
-    el.setAttribute('title', el.getAttribute('data-original-title'))
+    const originalTitle = el.getAttribute('data-original-title')
+    if (originalTitle) el.setAttribute('title', originalTitle)
 
     el.removeAttribute('data-original-title')
     el.removeAttribute('data-tooltipped')


### PR DESCRIPTION
When the `destroy` function is called the title attribute is set to `data-original-title` value even if it is undefined or null.
I discovered this issue by not passing the `title` prop to the Tooltip component and adding some custom behaviour to the popper using `open` and `disabled` props.
I just add a check for that value.