### PR TITLE
Fix component props type

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -59,7 +59,7 @@ export interface TooltipProps {
   style?: React.CSSProperties;
 }
 
-export class Tooltip extends React.Component<TooltipProps> {}
+export class Tooltip extends React.Component<React.PropsWithChildren<TooltipProps>> {}
 
 export declare function withTooltip<P>(
   component: React.ComponentType<P>,


### PR DESCRIPTION
Fixes the following error:

>Property 'children' does not exist on type 'IntrinsicAttributes & IntrinsicClassAttributes<Tooltip> & Readonly<TooltipProps>'.

It occurs when you use React 18 and pass children to the `<Tooltip>` component. Closes #169.