### PR TITLE
Event function classes for props

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -54,6 +54,8 @@ export interface TooltipProps {
   shown?: () => void;
   beforeHidden?: () => void;
   hidden?: () => void;
+  onShow?: () => void;
+  onHide?: () => void;
   theme?: Theme;
   className?: string;
   style?: React.CSSProperties;


### PR DESCRIPTION
This fixes the typescript issue, when trying to use those props.